### PR TITLE
Rename binaries to slither_cpp and slither_py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ vcpkg_installed/
 
 # Python packaging
 dist/
-pySlither.egg-info/
+slither_py.egg-info/
 __pycache__/
 *.pyc
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ Note: Python module links against libSlither in the build directory - don't dele
 python test/test_pyslither.py
 
 # C++ executable (self-explanatory arguments)
-./cppSlither --help
+./slither_cpp --help
 ```
 
 ## Architecture Overview

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,12 +89,12 @@ target_link_libraries(Slither PUBLIC OpenMP::OpenMP_CXX)
 #######################################
 # Build the Standalone executable
 #######################################
-add_executable(cppSlither source/main.cpp)
+add_executable(slither_cpp source/main.cpp)
 # Linking and including
-target_link_libraries(cppSlither PUBLIC Slither)
-target_link_libraries(cppSlither PUBLIC CLI11::CLI11)
+target_link_libraries(slither_cpp PUBLIC Slither)
+target_link_libraries(slither_cpp PUBLIC CLI11::CLI11)
 
-set_target_properties(cppSlither PROPERTIES
+set_target_properties(slither_cpp PROPERTIES
         CXX_STANDARD 17
         CXX_STANDARD_REQUIRED YES
         )
@@ -105,7 +105,7 @@ set_target_properties(cppSlither PROPERTIES
 #######################################
 # First --> Python requirements
 find_package(pybind11 CONFIG REQUIRED)
-pybind11_add_module(pySlither SHARED pyWrapper/wrapper.cpp)
-target_link_libraries(pySlither PRIVATE Slither)
+pybind11_add_module(slither_py SHARED pyWrapper/wrapper.cpp)
+target_link_libraries(slither_py PRIVATE Slither)
 
 

--- a/README.md
+++ b/README.md
@@ -93,23 +93,23 @@ python setup.py install
 
 ```bash
 # Basic usage
-./cppSlither --help
+./slither_cpp --help
 
 # Train a model
-./cppSlither --train data/train.txt --model forest.json --trees 100 --depth 15
+./slither_cpp --train data/train.txt --model forest.json --trees 100 --depth 15
 
 # Test a model
-./cppSlither --test data/test.txt --model forest.json --predict predictions.txt
+./slither_cpp --test data/test.txt --model forest.json --predict predictions.txt
 
 # Combined training and testing
-./cppSlither --train data/train.txt --test data/test.txt --model forest.json --op_mode tr-te
+./slither_cpp --train data/train.txt --test data/test.txt --model forest.json --op_mode tr-te
 ```
 
 ### Python API
 
 ```python
 import numpy as np
-from pySlither import SlitherWrapper
+from slither_py import SlitherWrapper
 
 # Create and train model
 model = SlitherWrapper()

--- a/pyWrapper/wrapper.cpp
+++ b/pyWrapper/wrapper.cpp
@@ -10,7 +10,7 @@ namespace py = pybind11;
 using namespace Slither;
 
 
-class slitherWrapper
+class SlitherWrapper
 {
     std::unique_ptr<Forest<LinearFeatureResponseSVM, HistogramAggregator> > forest;
     std::unique_ptr<DataPointCollection> data;
@@ -202,26 +202,26 @@ public:
 
 
 
-PYBIND11_MODULE(pySlither, m) {
+PYBIND11_MODULE(slither_py, m) {
     m.doc() = "slither -  a module to do awesome things";
 //    m.def("add", &add, "Simple function to add");
-    py::class_<slitherWrapper> slitherWrapObj(m, "slither");
+    py::class_<SlitherWrapper> slitherWrapObj(m, "slither");
     slitherWrapObj.def(py::init());
-    slitherWrapObj.def("add", &slitherWrapper::add);
-    slitherWrapObj.def("loadModel", &slitherWrapper::loadModel);
-    slitherWrapObj.def("saveModel", &slitherWrapper::saveModel);
-    slitherWrapObj.def("setDefaultParams", &slitherWrapper::setDefaultParams);
-    slitherWrapObj.def("setParams", &slitherWrapper::setParams);
-    slitherWrapObj.def("onlyTrain", &slitherWrapper::onlyTrain);
-    slitherWrapObj.def("onlyTest", &slitherWrapper::onlyTest);
-    slitherWrapObj.def("loadData", &slitherWrapper::loadData);
-    slitherWrapObj.def("modelExists", &slitherWrapper::modelExists);
-    slitherWrapObj.def("setThreads", &slitherWrapper::setThreads);
-    slitherWrapObj.def("setFeatureMask", &slitherWrapper::setFeatureMask);
-    slitherWrapObj.def("setMaxDecisionLevels", &slitherWrapper::setMaxDecisionLevels);
-    slitherWrapObj.def("setNumberOfCandidateFeatures",&slitherWrapper::setNumberOfCandidateFeatures);
-    slitherWrapObj.def("setNumberOfThresholds",&slitherWrapper::setNumberOfThresholds);
-    slitherWrapObj.def("setTrees",&slitherWrapper::setTrees);
-    slitherWrapObj.def("setQuiet",&slitherWrapper::setQuiet);
-    slitherWrapObj.def("setSVM_C",&slitherWrapper::setSVM_C);
+    slitherWrapObj.def("add", &SlitherWrapper::add);
+    slitherWrapObj.def("loadModel", &SlitherWrapper::loadModel);
+    slitherWrapObj.def("saveModel", &SlitherWrapper::saveModel);
+    slitherWrapObj.def("setDefaultParams", &SlitherWrapper::setDefaultParams);
+    slitherWrapObj.def("setParams", &SlitherWrapper::setParams);
+    slitherWrapObj.def("onlyTrain", &SlitherWrapper::onlyTrain);
+    slitherWrapObj.def("onlyTest", &SlitherWrapper::onlyTest);
+    slitherWrapObj.def("loadData", &SlitherWrapper::loadData);
+    slitherWrapObj.def("modelExists", &SlitherWrapper::modelExists);
+    slitherWrapObj.def("setThreads", &SlitherWrapper::setThreads);
+    slitherWrapObj.def("setFeatureMask", &SlitherWrapper::setFeatureMask);
+    slitherWrapObj.def("setMaxDecisionLevels", &SlitherWrapper::setMaxDecisionLevels);
+    slitherWrapObj.def("setNumberOfCandidateFeatures",&SlitherWrapper::setNumberOfCandidateFeatures);
+    slitherWrapObj.def("setNumberOfThresholds",&SlitherWrapper::setNumberOfThresholds);
+    slitherWrapObj.def("setTrees",&SlitherWrapper::setTrees);
+    slitherWrapObj.def("setQuiet",&SlitherWrapper::setQuiet);
+    slitherWrapObj.def("setSVM_C",&SlitherWrapper::setSVM_C);
 }

--- a/setup.py
+++ b/setup.py
@@ -57,14 +57,14 @@ class CMakeBuild(build_ext):
         subprocess.check_call(['cmake', '--build', '.'] + build_args, cwd=self.build_temp)
 
 setup(
-    name='pySlither',
+    name='slither_py',
     version='0.0.1',
     author='Prass, The Nomadic Chef',
     author_email='atemysemicolon@gmail.com',
     description='Incremental python bindings for Slither',
     long_description='',
     install_requires=['numpy'],
-    ext_modules=[CMakeExtension('pySlither')],
+    ext_modules=[CMakeExtension('slither_py')],
     cmdclass=dict(build_ext=CMakeBuild),
     zip_safe=False,
 )

--- a/test/test_pyslither.py
+++ b/test/test_pyslither.py
@@ -3,7 +3,7 @@
 Created on Wed Apr 20 17:52:56 2016
 Modified heavily on Oct 19
 
-This is a test end-to-end operation of pySlither
+This is a test end-to-end operation of slither_py
 1. Loading of Numpy Data
 2. Training a model
 3. Serialization (i.e Saving the model)
@@ -21,7 +21,7 @@ import os
 from sklearn import datasets, preprocessing
 
 # for the random forest library
-from pySlither import slither
+from slither_py import SlitherWrapper
 
 LOAD_IF_EXISTS = True
 
@@ -67,7 +67,7 @@ else:
     Y_test, X_test = cooltest[:, 0], cooltest[:, 1:]
 
 # Initialize the model
-my_slither = slither()
+my_slither = SlitherWrapper()
 my_slither.setDefaultParams()
 
 
@@ -85,5 +85,4 @@ else:
 # Testing a model - Always happens
 my_slither.loadData(X_test, Y_test)
 res_prob = my_slither.onlyTest()
-res_clf = np.argmax(res_prob, axis=1)
-print("I got : " + str(np.sum(res_clf == Y_test)) + "correct out of : " + str(len(Y_test)))
+res_clf = np.argmax(res_prob, axis=1)print("I got : " + str(np.sum(res_clf == Y_test)) + "correct out of : " + str(len(Y_test)))

--- a/test/test_wrapper.py
+++ b/test/test_wrapper.py
@@ -1,0 +1,11 @@
+import unittest
+
+from slither_py import SlitherWrapper
+
+class TestWrapper(unittest.TestCase):
+    def test_add(self):
+        wrapper = SlitherWrapper()
+        self.assertEqual(wrapper.add(2, 3), 5)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- rename C++ executable to `slither_cpp`
- rename Python extension module to `slither_py`
- update build files, tests, docs and gitignore to use new names

## Testing
- `./build.sh` *(fails: OpenCV not found)*
- `pytest -q` *(fails: ModuleNotFoundError for numpy and slither_py)*

------
https://chatgpt.com/codex/tasks/task_e_686e44f5ceec832091021719b5a7658f